### PR TITLE
Add feedback when performing unsupported action

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -7,30 +7,35 @@ from chalicelib.lib.factory import factory
 log = logging.getLogger(__name__)
 
 class Action:
-    
+
     def __init__(self, payload, config):
         self.payload = payload
         self.params = self.payload['text'][0].split()
         self.config = config
         self.slack_token = config['slack_token']
-    
+        self.response_url = self.payload['response_url'][0]
 
     def perform_action(self):
         self.action = self.params[0]
-        self.response_url = self.payload['response_url'][0]
         self.user_id = self.payload['user_id'][0]
 
         if self.action == 'add':
             return self._add_action()
-        
+
         if self.action == 'edit':
             return self._edit_action()
 
         if self.action == 'delete':
             return self._delete_action()
-        
+
         if self.action == 'list':
             return self._list_action()
+
+        return self._unsupported_action()
+
+    def _unsupported_action(self):
+        slack_responder(self.response_url, f'Unsupported action: {self.action}')
+        return ''
 
 
     def _add_action(self):
@@ -63,7 +68,7 @@ class Action:
         else:
             log.debug(f"Slack client response was: {slack_client_response.text}")
 
-        return ''    
+        return ''
 
     def _list_action(self):
         get_by_user = get_user_by_id(f"{self.config['backend_url']}/user", self.user_id)
@@ -105,7 +110,7 @@ class Action:
             return "Slack response to user failed"
         else:
             log.debug(f"Slack client response was: {slack_client_response.text}")
-    
+
 
     def _edit_action(self):
         slack_responder(self.response_url, 'Edit not implemented yet')

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,7 +1,20 @@
-from chalicelib.action import Action
+import pytest
+from mockito import when, mock, unstub
+import botocore.vendored.requests.api as requests
 
-def test_action_init():
-    fake_payload = dict(text=['fake', 'test'])
+@pytest.fixture
+def action():
+    fake_payload = dict(
+        text=['fake action', 'test'],
+        response_url=['http://fakeurl.nowhere'],
+        user_id=['fake user']
+    )
     fake_config = dict(slack_token='fake token')
-    test = Action(fake_payload, fake_config)
-    assert isinstance(test, Action)
+    from chalicelib.action import Action
+    return Action(fake_payload, fake_config)
+
+def test_perform_unsupported_action(action):
+    when(requests).post(
+        url=action.response_url, json={'text': 'Unsupported action: fake'}, headers={'Content-Type': 'application/json'}
+    ).thenReturn(mock({'status_code': 200}))
+    assert action.perform_action() == ''


### PR DESCRIPTION
If the action from the user is not matching any of the supported actions
in `Action` class then we will now send a response back that it's not
supported.

Maybe we can remove the whole config about valid actions and the
`verify_actions` functions that we doesn't even use.