### PR TITLE
Remove unused valid_actions

### DIFF
--- a/chalicelib/config.yaml
+++ b/chalicelib/config.yaml
@@ -3,8 +3,4 @@ valid_reasons:
   - sjuk
   - intern
   - semester
-valid_actions:
-  - add
-  - list
-  - delete
 log_level: DEBUG

--- a/chalicelib/lib/helpers.py
+++ b/chalicelib/lib/helpers.py
@@ -20,10 +20,3 @@ def verify_reasons(valid_reasons, reason):
         return True
     else:
         return False
-
-
-def verify_actions(valid_actions, action):
-    if action in valid_actions:
-        return True
-    else:
-        return False

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -158,13 +158,6 @@ def verify_reasons(valid_reasons, reason):
         return False
 
 
-def verify_actions(valid_actions, action):
-    if action in valid_actions:
-        return True
-    else:
-        return False
-
-
 def submit_message_menu(user_name, reason, date_start, date_end, hours):
     attachment = [
         {

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -3,9 +3,5 @@ valid_reasons:
   - sjuk
   - intern
   - semester
-valid_actions:
-  - add
-  - list
-  - show
 log_level: DEBUG
 backend_url: https://ywdi37qne9.execute-api.eu-north-1.amazonaws.com/api

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from chalicelib.lib.helpers import parse_config, verify_actions, verify_reasons
+from chalicelib.lib.helpers import parse_config, verify_reasons
 from chalicelib.lib.factory import factory, json_factory, date_to_string
 from chalicelib.lib.add import post_event
 from mockito import when, mock, unstub
@@ -64,11 +64,6 @@ def test_wrong_number_of_args_for_add(args_list):
 def test_verify_reason():
     assert verify_reasons(['not real reasons'], 'fake') is False
     assert verify_reasons(['my fake reason'], 'my fake reason') is True
-
-
-def test_verify_action():
-    assert verify_actions(['not a real action'], 'fake action') is False
-    assert verify_actions(['my fake action'], 'my fake action') is True
 
 
 def test_create_event():


### PR DESCRIPTION
With our class `Action` we now validate the supported actions in that
class.

The functions removed was never used, and the config for it wasn't used
either.