### PR TITLE
Initial support for help action

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -42,7 +42,7 @@ class Action:
         if self.action == "list":
             return self._list_action()
 
-        if self.action == "help" or self.action is None:
+        if self.action == "help":
             return self._help_action()
 
         return self._unsupported_action()

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -14,7 +14,13 @@ log = logging.getLogger(__name__)
 class Action:
     def __init__(self, payload, config):
         self.payload = payload
-        self.params = self.payload["text"][0].split()
+
+        try:
+            self.params = self.payload["text"][0].split()
+        except IndexError:
+            log.info("No parameters received. Defaulting to help action")
+            self.params = ["help"]
+
         self.config = config
         self.slack_token = config["slack_token"]
         self.response_url = self.payload["response_url"][0]

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -21,6 +21,7 @@ class Action:
 
     def perform_action(self):
         self.action = self.params[0]
+        log.debug(f"Action is: {self.action}")
         self.user_id = self.payload["user_id"][0]
 
         if self.action == "add":
@@ -35,10 +36,13 @@ class Action:
         if self.action == "list":
             return self._list_action()
 
+        if self.action == "help" or self.action is None:
+            return self._help_action()
+
         return self._unsupported_action()
 
     def _unsupported_action(self):
-        log.info(f"Got unsupported action: {self.action}")
+        log.info(f"Action: {self.action} is not supported")
         slack_responder(self.response_url, f"Unsupported action: {self.action}")
         return ""
 
@@ -111,3 +115,7 @@ class Action:
         else:
             log.debug(f"Slack client response was: {slack_client_response.text}")
         return slack_client_response
+
+    def _help_action(self):
+        slack_responder(self.response_url, "Help not implemented yet")
+        return ""

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -52,3 +52,18 @@ def test_perform_delete_action():
     when(action).send_response().thenReturn()
     assert action.perform_action() == ""
     unstub()
+
+
+def test_perform_help_action(caplog):
+    import logging
+    caplog.set_level(logging.DEBUG)
+    fake_payload["text"] = ["help"]
+    fake_payload["user_name"] = "fake_username"
+    action = Action(fake_payload, fake_config)
+    when(requests).post(
+        url=action.response_url,
+        json={"text": "Help not implemented yet"},
+        headers={"Content-Type": "application/json"},
+    ).thenReturn(mock({"status_code": 200}))
+    assert action.perform_action() == ""
+    unstub()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -53,11 +53,12 @@ def test_perform_delete_action():
     assert action.perform_action() == ""
     unstub()
 
-
-def test_perform_help_action(caplog):
-    import logging
-    caplog.set_level(logging.DEBUG)
-    fake_payload["text"] = ["help"]
+@pytest.mark.parametrize("test_input", [
+    (["help"]),
+    (""),
+])
+def test_perform_help_action(test_input):
+    fake_payload["text"] = test_input
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)
     when(requests).post(

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -15,11 +15,7 @@ fake_config = dict(slack_token="fake token")
 
 def test_perform_unsupported_action():
     action = Action(fake_payload, fake_config)
-    when(requests).post(
-        url=action.response_url,
-        json={"text": "Unsupported action: unsupported"},
-        headers={"Content-Type": "application/json"},
-    ).thenReturn(mock({"status_code": 200}))
+    when(action).send_response(message='Unsupported action: unsupported').thenReturn("")
     assert action.perform_action() == ""
     unstub()
 
@@ -27,11 +23,7 @@ def test_perform_unsupported_action():
 def test_perform_edit_action():
     fake_payload["text"] = ["edit fake argument"]
     action = Action(fake_payload, fake_config)
-    when(requests).post(
-        url=action.response_url,
-        json={"text": "Edit not implemented yet"},
-        headers={"Content-Type": "application/json"},
-    ).thenReturn(mock({"status_code": 200}))
+    when(action).send_response(message='Edit not implemented yet').thenReturn("")
     assert action.perform_action() == ""
     unstub()
 
@@ -61,10 +53,6 @@ def test_perform_help_action(test_input):
     fake_payload["text"] = test_input
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)
-    when(requests).post(
-        url=action.response_url,
-        json={"text": "Help not implemented yet"},
-        headers={"Content-Type": "application/json"},
-    ).thenReturn(mock({"status_code": 200}))
+    when(action).send_response(message=action.perform_action.__doc__).thenReturn("")
     assert action.perform_action() == ""
     unstub()


### PR DESCRIPTION
Will output a help message if `/timereport help` or `/timereport`.
Added test.
Probably need to refine how it's presented in slack later on.

Initial code for #55 