### PR TITLE
Change slack_token to bot_access_token and add a new signing_secret f…

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,8 @@ logger = logging.getLogger()
 dir_path = os.path.dirname(os.path.realpath(__file__))
 config = parse_config(f'{dir_path}/chalicelib/config.yaml')
 config['backend_url'] = os.getenv('backend_url')
-config['slack_token'] = os.getenv('slack_token')
+config['bot_access_token'] = os.getenv('bot_access_token')
+config['signing_secret'] = os.getenv('signing_secret')
 logger.setLevel(config['log_level'])
 
 @app.route('/interactive', methods=['POST'], content_types=['application/x-www-form-urlencoded'])
@@ -66,8 +67,8 @@ def index():
     req = app.current_request.raw_body.decode()
     req_headers = app.current_request.headers
     req_raw_body = app.current_request.raw_body
-    if not verify_token(req_headers, req_raw_body, config['slack_token']):
-        return 'Slack token not valid'
+    if not verify_token(req_headers, req_raw_body, config['signing_secret']):
+        return 'Slack signing secret not valid'
 
     payload = slack_payload_extractor(req)
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -22,7 +22,7 @@ class Action:
             self.params = ["help"]
 
         self.config = config
-        self.slack_token = config["slack_token"]
+        self.bot_access_token = config["bot_access_token"]
         self.response_url = self.payload["response_url"][0]
 
     def perform_action(self):
@@ -127,7 +127,7 @@ class Action:
             return ""
 
         slack_client_response = slack_client_responder(
-            token=self.slack_token, user_id=self.user_id, attachment=self.attachment
+            token=self.bot_access_token, user_id=self.user_id, attachment=self.attachment
         )
         if slack_client_response.status_code != 200:
             log.error(

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -159,10 +159,8 @@ def verify_token(headers, body, signing_secret):
     request_timestamp = headers['X-Slack-Request-Timestamp']
     request_basestring = bytes(f'v0:{request_timestamp}:{body}', 'utf-8')
     slack_signature = headers['X-Slack-Signature']
-    signing_secret = bytes(signing_secret, 'utf-8')
-    my_sig = f'v0={hmac.new(signing_secret, request_basestring, hashlib.sha256).hexdigest()}'
+    my_sig = f'v0={hmac.new(bytes(signing_secret, "utf-8"), request_basestring, hashlib.sha256).hexdigest()}'
 
-    # compare to slack-signature
     if hmac.compare_digest(my_sig, slack_signature):
         return True
     else:

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -10,7 +10,7 @@ fake_payload = dict(
     response_url=["http://fakeurl.nowhere"],
     user_id=["fake user"],
 )
-fake_config = dict(slack_token="fake token")
+fake_config = dict(bot_access_token="fake token")
 
 
 def test_perform_unsupported_action():

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -23,7 +23,7 @@ def test_slack_payload_extractor_payload():
     assert fake_data.get('fake') == 'fake data'
 
 
-def test_bot_access_token():
+def test_signing_secret():
     fake_request_headers = {'X-Slack-Request-Timestamp': '1531420618',
                             'X-Slack-Signature': 'v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503'
                             }

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -23,7 +23,7 @@ def test_slack_payload_extractor_payload():
     assert fake_data.get('fake') == 'fake data'
 
 
-def test_slack_token():
+def test_bot_access_token():
     fake_request_headers = {'X-Slack-Request-Timestamp': '1531420618',
                             'X-Slack-Signature': 'v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503'
                             }


### PR DESCRIPTION
fixes #87 !

Adds a signing_secret to chalice_secrets.tar and renames slack_token to bot_access_token which is what slack calls it