### PR TITLE
Refactoring list action and get_user_by_id

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -79,21 +79,33 @@ class Action:
         return ""
 
     def _list_action(self):
-        get_by_user = get_user_by_id(f"{self.config['backend_url']}/user", self.user_id)
-        if isinstance(get_by_user, tuple):
-            log.debug(f"Failed to return anything: {get_by_user[1]}")
+
+        default_arg = "all"
+        try:
+            arguments = self.params[1]
+        except IndexError:
+            log.debug(f"No arguments for list. Setting default value: {default_arg}")
+            arguments = default_arg
+
+        list_data = get_user_by_id(f"{self.config['backend_url']}", self.user_id)
+        
+        if not list_data:
+            log.error(f"Unable to get list data for user {self.user_id}")
+            return ""
+        
+        if arguments == "today":
+            self.send_response(message="Today argument not implemented yet")
+            return ""
+        
+        if arguments == "all":
+            self.send_response(message=f"```{str(list_data)}```")
+            return ""
         else:
-            for r in get_by_user:
-                self.send_response(message=f"```{str(r)}```")
-
-        event_date = "".join(self.params[-1:])
-        if ":" in event_date:
-            # temporary solution
-
+            event_date = "".join(self.params[-1:])
             start_date, end_date = event_date.split(":")
 
             get_by_date = get_between_date(
-                f"{self.config['backend_url']}/user/{self.user_id}",
+                f"{self.config['backend_url']}/{self.user_id}",
                 start_date,
                 end_date,
             )

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -105,7 +105,7 @@ class Action:
             start_date, end_date = event_date.split(":")
 
             get_by_date = get_between_date(
-                f"{self.config['backend_url']}/{self.user_id}",
+                f"{self.config['backend_url']}/user/{self.user_id}",
                 start_date,
                 end_date,
             )

--- a/chalicelib/lib/list.py
+++ b/chalicelib/lib/list.py
@@ -5,19 +5,18 @@ log = logging.getLogger(__name__)
 
 def get_user_by_id(url, user_id):
     """
-    Uses new python chalice backend
-    only returns back at this point, no DB connection
+    List all posts for user
 
-    :method: GET
-    :url: /timereport/user/{user_id}
-    :return: {'user_id': user_id}
+    :url: The URL to the API
+    :user_id: The user_id
+    :return: response object
     """
-    url = url + '/' + user_id
-    res = requests.get(url=url)
-    if res.status_code == 200:
-        log.debug(f'{res.text}')
-        yield res.text
+    api_url = f"{url}/user/{user_id}"
+    response = requests.get(url=api_url)
+    if response.status_code == 200:
+        return response.text
     else:
+        log.debug(f"Got response code {response.status_code} for user ID {user_id}")
         return False
 
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -67,9 +67,7 @@ def test_perform_empty_action():
     unstub()
 
 
-def test_perform_list_action(caplog):
-    import logging
-    caplog.set_level(logging.DEBUG)
+def test_perform_list_action():
     fake_payload["text"] = ["list"]
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -3,6 +3,7 @@ import pytest
 from chalicelib.lib.helpers import parse_config, verify_reasons
 from chalicelib.lib.factory import factory, json_factory, date_to_string
 from chalicelib.lib.add import post_event
+from chalicelib.lib.list import get_user_by_id
 from mockito import when, mock, unstub
 import botocore.vendored.requests.api as requests
 from datetime import datetime
@@ -100,3 +101,11 @@ def test_date_to_string():
     test_data = date_to_string(datetime.now())
     assert isinstance(test_data, str)
 
+
+def test_get_user_by_id():
+    when(requests).get(
+        url='http://fake.nowhere/user/fake_userid',
+    ).thenReturn(mock({"status_code": 200, "text": "fake get_user_by_id response"}))
+    test = get_user_by_id(url='http://fake.nowhere', user_id='fake_userid')
+    unstub()
+    assert isinstance(test, str)


### PR DESCRIPTION
In order to solve ticket #52 I felt I wanted to refactor the existing
list action and the get_user_by_id.

The changes to get_user_by_id is mostly use return instead of yield.
Before we mixed both return and yield which is not a good thing to do.
Also, there was no point of yielding when we only call this function
once per list action.

Added initial logic for list action to support "today".
Added test for get_user_by_id.