### PR TITLE
Check response from request when adding event

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,8 +54,14 @@ def interactive():
         if payload.get('callback_id') == 'add':
             events = json_factory(payload)
             for event in events:
-                post_event(f"{config['backend_url']}/event/users/{user_id}", json.dumps(event))
-            logger.info(f"python url is: {config['backend_url']}")
+                response = post_event(f"{config['backend_url']}/event/users/{user_id}", json.dumps(event))
+
+                if response.status_code != 200:
+                    logger.debug(
+                        f"Event {event} got unexpected response from backend: {response.text}"
+                    )
+                    slack_responder(url=response_url, msg=f'Failed to create event {event}')
+
             slack_responder(url=response_url, msg='Added successfully')
             return ''
     else:

--- a/chalicelib/lib/add.py
+++ b/chalicelib/lib/add.py
@@ -5,16 +5,13 @@ log = logging.getLogger(__name__)
 
 def post_event(url, data):
     """
-    Uses new python chalice backend
-    only returns back at this point, no DB connection
+    Add event
 
-    :method: POST
-    :url: '/event'
-    :return: current_request.raw_body.decode() (same data you send in)
+    url: URL to backend API
+    data: A dict with the event to add
+    
+    :return: requests response object
     """
-    headers={'Content-Type': 'application/json'}
+    headers = {'Content-Type': 'application/json'}
     res = requests.post(url=url, json=data, headers=headers)
-    if res.status_code == 200:
-        return True
-    else:
-        return False
+    return res

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -69,8 +69,8 @@ def test_create_event():
     when(requests).post(
         url=fake_url, json=fake_data, headers={"Content-Type": "application/json"}
     ).thenReturn(mock({"status_code": 200}))
-
-    assert post_event(fake_url, fake_data) is True
+    response = post_event(fake_url, fake_data)
+    assert response.status_code == 200
     unstub()
 
 
@@ -80,7 +80,8 @@ def test_create_event_failure():
     when(requests).post(
         url=fake_url, json=fake_data, headers={"Content-Type": "application/json"}
     ).thenReturn(mock({"status_code": 500}))
-    assert post_event(fake_url, fake_data) is False
+    response = post_event(fake_url, fake_data)
+    assert response.status_code != 200
     unstub()
 
 


### PR DESCRIPTION
It will now send a message to slack if one event failed.

#101 