### PR TITLE
Fix scoping bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,9 +54,9 @@ def interactive():
         if payload.get('callback_id') == 'add':
             msg = 'Added successfully'
             events = json_factory(payload)
+            failed_events = list()
             for event in events:
                 response = post_event(f"{config['backend_url']}/event/users/{user_id}", json.dumps(event))
-                failed_events = list()
                 if response.status_code != 200:
                     logger.debug(
                         f"Event {event} got unexpected response from backend: {response.text}"


### PR DESCRIPTION
I believe the reason for not getting the failed events in the response
from slack was due to the variable was out of scope.

#101 