### PR TITLE
Change default date string to month

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -101,8 +101,9 @@ class Action:
         "today" - List the event for the todays date
         "date" - The date as a string. Use ":" as delimiter for two dates: "2019-01-01:2019-01-02"
         """
-
-        date_str = "all"
+        month = datetime.now().strftime("%Y-%m")
+        # A hack to set the date_str to the current month
+        date_str = f"{month}-01:{month}-31"
         arguments = self.params[1:]
 
         log.debug(f"Got arguments: {arguments}")
@@ -112,8 +113,9 @@ class Action:
             else:
                 date_str = arguments[0]
         except IndexError as error:
-            log.debug(f"got expected exception: {error}", exc_info=True)
+            log.debug(f"got unexpected exception: {error}", exc_info=True)
             
+        log.debug(f"The date string set to: {date_str}")
         list_data = self._get_events(date_str=date_str)
 
         if not list_data or list_data == '[]':

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -2,6 +2,7 @@ import pytest
 from mockito import when, mock, unstub
 import botocore.vendored.requests.api as requests
 from chalicelib.action import Action
+from datetime import datetime
 from . import test_data
 import json
 
@@ -82,9 +83,15 @@ def test_perform_list_action():
     fake_payload["text"] = ["list"]
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)
+    month = datetime.now().strftime("%Y-%m")
+    
     when(action).send_response(message="```fake list output```").thenReturn("")
     when(requests).get(
-        url=f"{fake_config['backend_url']}/event/users/fake_userid", params=None
+        url=f"{fake_config['backend_url']}/event/users/fake_userid", 
+        params={
+            "startDate": datetime.now().strftime("%Y-%m-01"),
+            "endDate": datetime.now().strftime("%Y-%m-31"),
+        }
     ).thenReturn(mock({"status_code": 200, "text": "fake list output"}))
     assert action.perform_action() == ""
     unstub()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -83,7 +83,6 @@ def test_perform_list_action():
     fake_payload["text"] = ["list"]
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)
-    month = datetime.now().strftime("%Y-%m")
     
     when(action).send_response(message="```fake list output```").thenReturn("")
     when(requests).get(


### PR DESCRIPTION
A quite ugly hack to set the default date string to the given month.
I know that not every month have 31 days, but it really doesn't matter
I think :)

Relates to #96