### PR TITLE
Add support for month

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -99,11 +99,8 @@ class Action:
 
         Supported arguments:
         "today" - List the event for the todays date
-        "date" - The date as a string. Use ":" as delimiter for two dates: "2019-01-01:2019-01-02"
+        "date" - The date as a string.
         """
-        month = datetime.now().strftime("%Y-%m")
-        # A hack to set the date_str to the current month
-        date_str = f"{month}-01:{month}-31"
         arguments = self.params[1:]
 
         log.debug(f"Got arguments: {arguments}")
@@ -112,8 +109,15 @@ class Action:
                 date_str = datetime.now().strftime("%Y-%m-%d")
             else:
                 date_str = arguments[0]
-        except IndexError as error:
+        except IndexError:
+            month = datetime.now().strftime("%Y-%m")
+            # A hack to set the date_str to the current month
+            date_str = f"{month}-01:{month}-31"
+            arguments = self.params[1:]
+        except Exception as error:
             log.debug(f"got unexpected exception: {error}", exc_info=True)
+            self.send_response(message=f"Got unexpected error with arguments: {arguments}")
+            return ""
             
         log.debug(f"The date string set to: {date_str}")
         list_data = self._get_events(date_str=date_str)

--- a/chalicelib/lib/list.py
+++ b/chalicelib/lib/list.py
@@ -1,28 +1,35 @@
 import botocore.vendored.requests.api as requests
 import logging
+from datetime import datetime
 
 log = logging.getLogger(__name__)
 
 
-def get_list_data(url, user_id, date_str=None):
+def get_list_data(url, user_id, date_str):
     """
     Get existing timereport for a user
 
     :url: The URL to the backend API
     :user_id: The users user ID
-    :date_str: A string contaning date. Valid formats: "2019-01-01", "2019-01-02:2019-01-03"
+    :date_str: A string contaning date. Valid formats: "2019-01", "2019-01-01", "2019-01-02:2019-01-03"
     """
     api_url = f"{url}/event/users/{user_id}"
-    date_str = None if date_str == "all" else date_str
-    if date_str:
-        try:
-            start_date, end_date = date_str.split(":")
-        except ValueError as error:
-            log.debug(f"Failed to split: {date_str}")
-            log.debug(f"Error was: {error}", exc_info=True)
+    try:
+        start_date, end_date = date_str.split(":")
+    except ValueError as error:
+        log.debug(f"Failed to split: {date_str}")
+
+        if len(date_str.split("-")) == 2:
+            start_date = f"{date_str}-01"
+            end_date = f"{date_str}-31"
+        else:
             start_date, end_date = date_str, date_str
 
-        date_str = {"startDate": start_date, "endDate": end_date}
+    except Exception as error:
+        log.debug(f"Unexpected exception. Error was: {error}", exc_info=True)
+        return False
+
+    date_str = {"startDate": start_date, "endDate": end_date}
 
     response = requests.get(url=api_url, params=date_str)
     if response.status_code == 200:

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -99,17 +99,18 @@ def test_date_to_string():
     assert isinstance(test_data, str)
 
 
-def test_get_list_data():
+def test_get_list_data_default():
+    month = datetime.now().strftime("%Y-%m") 
     fake_response = "fake list data response"
     when(requests).get(
         url=fake_user_url,
         params={
-            'startDate': "2019-01-01",
-            'endDate': "2019-01-01"
+            'startDate': f"{month}-01",
+            'endDate': f"{month}-31"
         }
     ).thenReturn(mock({"status_code": 200, "text": fake_response}))
     test = get_list_data(
-        url="http://fake.nowhere", user_id="fake_userid", date_str="2019-01-01"
+        url="http://fake.nowhere", user_id="fake_userid", date_str=datetime.now().strftime("%Y-%m")
     )
     unstub()
     assert test == fake_response

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -102,10 +102,14 @@ def test_date_to_string():
 def test_get_list_data():
     fake_response = "fake list data response"
     when(requests).get(
-        url=fake_user_url, params=None
+        url=fake_user_url,
+        params={
+            'startDate': "2019-01-01",
+            'endDate': "2019-01-01"
+        }
     ).thenReturn(mock({"status_code": 200, "text": fake_response}))
     test = get_list_data(
-        url="http://fake.nowhere", user_id="fake_userid", date_str=None
+        url="http://fake.nowhere", user_id="fake_userid", date_str="2019-01-01"
     )
     unstub()
     assert test == fake_response
@@ -139,11 +143,30 @@ def test_get_list_data_date_range():
     assert test == fake_response
 
 
+def test_get_list_data_month():
+    fake_response = "fake list data response"
+    when(requests).get(
+        url=fake_user_url,
+        params={"startDate": "2019-01-01", "endDate": "2019-01-31"},
+    ).thenReturn(mock({"status_code": 200, "text": fake_response}))
+    test = get_list_data(
+        url="http://fake.nowhere",
+        user_id="fake_userid",
+        date_str="2019-01",
+    )
+    unstub()
+    assert test == fake_response
+
+
 def test_get_list_data_faulty_response():
     when(requests).get(
-        url=fake_user_url, params=None
+        url=fake_user_url,
+        params={
+            'startDate': "2019-01-01",
+            'endDate': "2019-01-01",
+        }
     ).thenReturn(mock({"status_code": 500}))
-    test = get_list_data(url="http://fake.nowhere", user_id="fake_userid")
+    test = get_list_data(url="http://fake.nowhere", user_id="fake_userid", date_str="2019-01-01")
     unstub()
     assert test is False
 


### PR DESCRIPTION
This adds support to specify a month for `/timereport list`.
Example: `/timereport list 2019-01`.

Maybe not the most bulletproof way of checking stuff, and feels a bit over complicated.
But it works.
 
If you guys have a suggestion to make it better I'm all for it. 

#96 
