### PR TITLE
Add slack client

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -86,11 +86,10 @@ class Action:
         if self.check_lock_state():
             return self.send_response(message="One or more of the events are locked")
 
-        self.attachment = submit_message_menu(
-            user_name, reason, self.date_start, self.date_end, hours
+        self.send_attachment(attachment=submit_message_menu(
+            user_name, reason, 
+            self.date_start, self.date_end, hours)
         )
-        log.info(f"Attachment is: {self.attachment}")
-        self.send_response()
         return ""
 
     def _list_action(self):
@@ -133,34 +132,37 @@ class Action:
 
     def _delete_action(self):
         date = self.params[1]
-        self.attachment = delete_message_menu(self.payload.get("user_name")[0], date)
-        log.debug(
-            f"Attachment is: {self.attachment}. user_name is {self.payload.get('user_name')[0]}"
-        )
-        self.send_response()
+        self.send_attachment(attachment=delete_message_menu(self.payload.get("user_name")[0], date))
         return ""
 
     def _edit_action(self):
         return self.send_response(message="Edit not implemented yet")
 
-    def send_response(self, message=False):
+
+    def send_response(self, message):
         """
         Send a response to slack
 
-        If param message is False the attribute self.attachment is excpected
-        to exist.
+        :message: The Message to send
         """
-        if message:
-            log.debug("Sending message to slack")
-            self.slack.client.chat_postMessage(
-                channel=self.user_id,
-                text=message,
-            )
-            return ""
+  
+        log.debug("Sending message to slack")
+        self.slack.client.chat_postMessage(
+            channel=self.user_id,
+            text=message,
+        )
+        return ""
+
+    def send_attachment(self, attachment):
+        """
+        Send an message to slack using attachment
+        :attachment: The attachment (slack specific attachment) to send
+        """
+
         slack_client_response = slack_client_responder(
             token=self.bot_access_token,
             user_id=self.user_id,
-            attachment=self.attachment,
+            attachment=attachment,
         )
 
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -2,7 +2,6 @@ import logging
 import json
 from chalicelib.lib.list import get_list_data
 from chalicelib.lib.slack import (
-    slack_responder,
     submit_message_menu,
     slack_client_responder,
     delete_message_menu,

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -6,8 +6,16 @@ import json
 import hmac
 import hashlib
 import base64
+import slack
 
 log = logging.getLogger(__name__)
+
+
+class Slack:
+
+    def __init__(self, slack_token):
+        self.slack_token = slack_token
+        self.client = slack.WebClient(token=slack_token)
 
 
 def slack_client_responder(token, user_id, attachment, url='https://slack.com/api/chat.postMessage'):

--- a/deploy-requirements.txt
+++ b/deploy-requirements.txt
@@ -1,3 +1,4 @@
 chalice
 botocore
 ruamel.yaml
+slackclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ruamel.yaml
+slackclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 ruamel.yaml
-slackclient

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 ruamel-yaml
 mockito
 botocore
+slackclient

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -39,7 +39,7 @@ def test_perform_add_action():
     action.user_id = "fake_userid"
     action.date_start = "2019-01-01"
     action.date_end = "2019-01-01"
-    when(action).send_response().thenReturn()
+    when(action).send_response(message="").thenReturn()
     when(requests).get(
         url=f"{fake_config['backend_url']}/event/users/{action.user_id}", 
         params={
@@ -55,7 +55,7 @@ def test_perform_delete_action():
     fake_payload["text"] = ["delete 2019-01-01"]
     fake_payload["user_name"] = "fake_username"
     action = Action(fake_payload, fake_config)
-    when(action).send_response().thenReturn()
+    when(action).send_response(message="").thenReturn()
     assert action.perform_action() == ""
     unstub()
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -2,9 +2,11 @@ import os
 from mockito import when, mock, unstub
 from .test_data import fake_request_body
 import botocore.vendored.requests.api as requests
-from chalicelib.lib.slack import (slack_payload_extractor, verify_token,
-                                  slack_client_responder, slack_responder,
-                                  submit_message_menu, delete_message_menu)
+from chalicelib.lib.slack import (
+    slack_payload_extractor, verify_token,
+    submit_message_menu, delete_message_menu,
+    slack_client_responder, slack_responder, Slack
+)
 
 
 
@@ -103,3 +105,9 @@ def test_delete_menu():
 
     assert isinstance(test_result_dict, dict)
     assert test_result_dict.get('fields')
+
+
+def test_slack_class():
+    test = Slack(slack_token="fake_token")
+    assert test.slack_token
+    assert test.client


### PR DESCRIPTION
Use slack client for some of our responses.
The messages that don't use any "attachment" will be sent using this client.
The complete migration to slack client will be handled in #110 and #111 