### PR TITLE
Use update message slack method

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,12 +31,15 @@ def interactive():
     req = app.current_request.raw_body.decode()
     payload = slack_payload_extractor(req)
     selection = payload.get('actions')[0].get('value')
+    slack_timestamp = payload['original_message']['ts']
+    user_id = payload['user']['id']
+
     logger.info(f"Selection is: {selection}")
+    logger.debug(f"User id is: {user_id}")
+    logger.debug(f"Slack message timestamp is: {slack_timestamp}")
     slack_response_message = "Action canceled :x:"
-    user_id = None
 
     if selection == "submit_yes":
-        user_id = payload['user']['id']
         if payload.get('callback_id') == 'delete':
             message = payload['original_message']['attachments'][0]['fields']
             date = message[1]['value']
@@ -50,9 +53,10 @@ def interactive():
             else:
                 slack_response_message = f'successfully deleted entry: {date}'
 
-            slack.client.chat_postMessage(
+            slack.client.chat_update(
                 channel=user_id,
                 text=slack_response_message,
+                ts=slack_timestamp,
             )
             return ''
 
@@ -75,9 +79,10 @@ def interactive():
                     f"These however failed: ```{failed_events} ```"
                 )
     
-    slack.client.chat_postMessage(
+    slack.client.chat_update(
         channel=user_id,
         text=slack_response_message,
+        ts=slack_timestamp,
     )
     return ''
 


### PR DESCRIPTION
When I removed the response URL it changed the behaviour a bit.
Instead of updating the interactive message it would just post a new message instead.
We want the interacive message to be  updated.
#110 