### PR TITLE
Add method to validate the response from slack

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -156,11 +156,10 @@ class Action:
         """
   
         log.debug("Sending message to slack")
-        response = self.slack.post_message(
+        self.slack.post_message(
             channel=self.user_id,
             message=message,
         )
-        log.debug(f"Response was: {response.text}")
         return ""
 
     def send_block(self, message):

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -25,12 +25,30 @@ class Slack:
         :param channel: The channel to send the message
         :return: requests.models.Response
         """
-        return requests.post(
-            url=f"{self.slack_api_url}/chat.postMessage",
-            json={"channel": channel, "text": f"{message}"},
-            headers=self.headers,
+        return self._handle_response(
+            requests.post(
+                url=f"{self.slack_api_url}/chat.postMessage",
+                json={"channel": channel, "text": f"{message}"},
+                headers=self.headers,
+            )
         )
 
+
+    def _handle_response(self, response: requests.models.Response) -> None:
+        """
+        Check the response from slack.
+        A normal slack response should always be JSON with a key "ok" with value True for the response to be valid
+
+        """
+        try:
+            validated_response = response.json()
+            if not validated_response.get('ok'):
+                log.critical(f"Slack responded with not ok. Message was: {validated_response}")
+        except AttributeError as error:
+            log.critical(f"Unable get valid json from response. Error was: {error}", exc_info=True)
+        
+        return None
+            
 
 def slack_client_responder(token, user_id, attachment, url='https://slack.com/api/chat.postMessage'):
     """

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -34,7 +34,7 @@ class Slack:
         )
 
 
-    def _handle_response(self, response: requests.models.Response) -> None:
+    def _handle_response(self, response: requests.models.Response) -> requests.models.Response:
         """
         Check the response from slack.
         A normal slack response should always be JSON with a key "ok" with value True for the response to be valid
@@ -44,10 +44,10 @@ class Slack:
             validated_response = response.json()
             if not validated_response.get('ok'):
                 log.critical(f"Slack responded with not ok. Message was: {validated_response}")
-        except AttributeError as error:
+        except (AttributeError, ValueError) as error:
             log.critical(f"Unable get valid json from response. Error was: {error}", exc_info=True)
         
-        return None
+        return response
             
 
 def slack_client_responder(token, user_id, attachment, url='https://slack.com/api/chat.postMessage'):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -110,4 +110,4 @@ def test_delete_menu():
 
 
 def test_slack_handle_response_wrong_data_type():
-    assert fake_slack._handle_response("wrong data type") is None
+    assert fake_slack._handle_response("wrong data type") is not None

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -8,6 +8,7 @@ from chalicelib.lib.slack import (
     slack_client_responder, slack_responder, Slack
 )
 
+fake_slack = Slack(slack_token="fake")
 
 
 def test_slack_payload_extractor_command():
@@ -106,3 +107,7 @@ def test_delete_menu():
 
     assert isinstance(test_result_dict, dict)
     assert test_result_dict.get('fields')
+
+
+def test_slack_handle_response_wrong_data_type():
+    assert fake_slack._handle_response("wrong data type") is None


### PR DESCRIPTION
Add a response handler method for other Slack class methods to use to validate the response from slack.

This fix is only for those that use the Slack class. When we have refactored slack.py (see #132 ) and migrated to only use this class it will be implemented completely

#67 