### PR TITLE
Initial support for edit action

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -37,10 +37,10 @@ class Action:
         Perform action.
 
         Supported actions are:
-        add - Add new post in timereport
-        edit - Not implemented yet
-        delete - Delete post in timereport
-        list - List posts in timereport
+        add - Add one or more events in timereport
+        edit - Edit a single event in timereport
+        delete - Delete event in timereport
+        list - List one or more events in timereport
         lock - Not implemented yet
         help - Provide this helpful output
         """
@@ -145,7 +145,30 @@ class Action:
         return ""
 
     def _edit_action(self):
-        return self.send_response(message="Edit not implemented yet")
+        """
+        Edit event in timereport for user.
+        If no arguments supplied it will try to edit today.
+        """
+        
+        date = datetime.now().strftime("%Y-%m-%d")
+
+        try:
+            date = self.params[1]
+            if self.params[1] != "today":
+                date = self.params[1]
+        except IndexError:
+            log.debug(f"Didn't get any params. Setting date to {date}")
+
+        event_to_edit = self._get_events(date_str=date)
+        log.debug(f"Event to edit is: {event_to_edit}")
+        
+        if event_to_edit == '[]':
+            self.send_response(message=f"No event for date {date} to edit. :shrug:")
+        else:
+            self.send_response(message=f"Found event to edit, but I can't do that yet, sorry. :cry:")
+
+
+        return ""
 
 
     def send_response(self, message):

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -158,14 +158,21 @@ class Action:
         except IndexError:
             log.debug(f"Didn't get any params. Setting date to {date}")
 
-        event_to_edit = self._get_events(date_str=date)
-        log.debug(f"Event to edit is: {event_to_edit}")
+        event_to_edit = None
+        try:
+            json.loads(self._get_events(date_str=date))
+        except json.decoder.JSONDecodeError as error:
+            log.error(f"Unable to decode JSON. Error was: {error}")
+            self.send_response(message=f"Something went wrong fetching event to edit. :cry:")
+            return ""
         
-        if event_to_edit == '[]':
+        log.debug(f"Event to edit is: {event_to_edit}")
+        if not event_to_edit:
             self.send_response(message=f"No event for date {date} to edit. :shrug:")
-        else:
-            self.send_response(message=f"Found event to edit, but I can't do that yet, sorry. :cry:")
+            return ""
 
+
+        self.send_response(message=f"Found event to edit, but I can't do that yet, sorry. :cry:")
 
         return ""
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -153,7 +153,6 @@ class Action:
         date = datetime.now().strftime("%Y-%m-%d")
 
         try:
-            date = self.params[1]
             if self.params[1] != "today":
                 date = self.params[1]
         except IndexError:

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -160,7 +160,7 @@ class Action:
 
         event_to_edit = None
         try:
-            json.loads(self._get_events(date_str=date))
+            event_to_edit = json.loads(self._get_events(date_str=date))
         except json.decoder.JSONDecodeError as error:
             log.error(f"Unable to decode JSON. Error was: {error}")
             self.send_response(message=f"Something went wrong fetching event to edit. :cry:")

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -25,10 +25,11 @@ def test_perform_unsupported_action():
     unstub()
 
 
-def test_perform_edit_action():
+def test_perform_empty_edit_action():
     fake_payload["text"] = ["edit 2019-01-01"]
     action = Action(fake_payload, fake_config)
-    when(action)._get_events(date_str="2019-01-01").thenReturn("")
+    when(action).send_response(message="No event for date 2019-01-01 to edit. :shrug:").thenReturn()
+    when(action)._get_events(date_str="2019-01-01").thenReturn('[]')
     assert action.perform_action() == ""
     unstub()
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -26,9 +26,9 @@ def test_perform_unsupported_action():
 
 
 def test_perform_edit_action():
-    fake_payload["text"] = ["edit fake argument"]
+    fake_payload["text"] = ["edit 2019-01-01"]
     action = Action(fake_payload, fake_config)
-    when(action).send_response(message="Edit not implemented yet").thenReturn("")
+    when(action)._get_events(date_str="2019-01-01").thenReturn("")
     assert action.perform_action() == ""
     unstub()
 


### PR DESCRIPTION
Add support for edit action. It will initially only say either no event to edit for the date specified
or that it's not possible to edit right now. 

I want to keep the changes small to make it easier for reviews. More functionality will be added in iterations.

#12 