### PR TITLE
Improve _edit_action

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -193,12 +193,12 @@ class Action:
         If no arguments supplied it will try to edit today.
         """
         try:
-            date_string = self.params[1]
+            date_input = self.params[1]
         except IndexError:
-            date_string = "today"
-            log.debug(f"Didn't get any params. Setting date to {date_string}")
+            date_input = "today"
+            log.debug(f"Didn't get any params. Setting date to {date_input}")
 
-        date = parse_date(date_string, format_str=self.format_str)
+        date = parse_date(date_input, format_str=self.format_str)
         if not date:
             self.send_response(message="failed to parse date {date_string}")
 
@@ -207,12 +207,12 @@ class Action:
 
         if self._check_locks(date=date[0], second_date=date[0]):
             return self.send_response(
-                message=f"Can't edit date {date_string} because locked month :cry:"
+                message=f"Can't edit date {date_input} because locked month :cry:"
             )
 
         event_to_edit = None
         try:
-            event_to_edit = json.loads(self._get_events(date_str=date_string))
+            event_to_edit = json.loads(self._get_events(date_str=date_input))
         except json.decoder.JSONDecodeError as error:
             log.error(f"Unable to decode JSON. Error was: {error}")
             self.send_response(

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -200,14 +200,14 @@ class Action:
 
         date = parse_date(date_string, format_str=self.format_str)
         if not date:
-            self.send_response(message="failed to parse date {date}")
+            self.send_response(message="failed to parse date {date_string}")
 
         if len(date) > 1:
             return self.send_response(message=f"Edit doesn't support date range :cry:")
 
         if self._check_locks(date=date[0], second_date=date[0]):
             return self.send_response(
-                message=f"Can't edit date {date} because locked month :cry:"
+                message=f"Can't edit date {date_string} because locked month :cry:"
             )
 
         event_to_edit = None

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -28,17 +28,6 @@ def test_perform_unsupported_action():
     unstub()
 
 
-def test_perform_empty_edit_action():
-    fake_payload["text"] = ["edit 2019-01-01"]
-    action = Action(fake_payload, fake_config)
-    when(action).send_response(
-        message="No event for date 2019-01-01 to edit. :shrug:"
-    ).thenReturn()
-    when(action)._get_events(date_str="2019-01-01").thenReturn("[]")
-    assert action.perform_action() == ""
-    unstub()
-
-
 def test_perform_help_action():
     fake_payload["text"] = ["help"]
     fake_payload["user_name"] = "fake_username"


### PR DESCRIPTION
Improve the _edit_action implementation:
* use `parse_date` function to handle the converstion of string to datetime
* Send message if wrong date format (including if the user tried to use a date range which isn't supported yet)
* Send message if the month the user tries to edit is locked.

#12