### PR TITLE
Refactor _valid_number_of_args

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -350,18 +350,14 @@ class Action:
 
         return is_locked
 
-    def _valid_number_of_args(self, min_args: int, max_args: int = None) -> bool:
+    def _valid_number_of_args(self, min_args: int, max_args: int) -> bool:
         """
         Check that the number of arguments in the list is within the valid range
         """
         log.debug(f"Got {len(self.arguments)} number of args")
-        if len(self.arguments) < min_args:
-            return False
-
-        if max_args and len(self.arguments) > max_args:
-            return False
-
-        return True
+        if min_args <= len(self.arguments) <= max_args:
+            return True
+        return False
 
     def _valid_reason(self, reason: str) -> bool:
         """

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -83,7 +83,7 @@ def test_valid_number_of_args():
     fake_action.arguments = ["fake_arg_1"]
 
     # Should be valid since we have provided the minimum amount
-    assert fake_action._valid_number_of_args(min_args=1) is True
+    assert fake_action._valid_number_of_args(min_args=1, max_args=1) is True
 
     fake_action.arguments.append("fake_arg_2")
 
@@ -91,7 +91,7 @@ def test_valid_number_of_args():
     assert fake_action._valid_number_of_args(min_args=1, max_args=2) is True
 
     # Should be false since we don't have the minimum amount
-    assert fake_action._valid_number_of_args(min_args=3) is False
+    assert fake_action._valid_number_of_args(min_args=3, max_args=3) is False
 
     # Should be false since we don't have the maximum amount
     assert fake_action._valid_number_of_args(min_args=1, max_args=1) is False


### PR DESCRIPTION
The max argument is now no longer optional.
Use interval comparison.