### PR TITLE
Remove `slack_client_block_responder` function

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -7,7 +7,6 @@ from chalicelib.lib.slack import (
     submit_message_menu,
     slack_client_responder,
     delete_message_menu,
-    slack_client_block_responder,
     Slack,
     create_block_message,
 )
@@ -163,7 +162,12 @@ class Action:
                 message=f"Sorry, nothing to list with supplied argument {arguments}"
             )
             return ""
-        self.send_block(message=list_data)
+
+        self.slack.post_message(
+            message="From timereport",
+            channel=self.user_id,
+            blocks=create_block_message(json.loads(list_data)),
+        )
         return ""
 
     def _delete_action(self):
@@ -263,31 +267,6 @@ class Action:
         log.debug("Sending message to slack")
         self.slack.post_message(channel=self.user_id, message=message)
         return ""
-
-    def send_block(self, message):
-        """
-        Send a response to slack using blocks and WEB API
-        :message: The message is a list of dicts
-
-        [{"user_id": "U2FGC795G", "hours": "8", "user_name": "kamger", "event_date": "2019-08-30", "reason": "intern_arbete"}]
-
-        """
-        # will generate a block object
-        block = create_block_message(json.loads(message))
-
-        slack_client_response = slack_client_block_responder(
-            token=self.bot_access_token, user_id=self.user_id, block=block
-        )
-
-        if slack_client_response.status_code != 200:
-            log.error(
-                f"""Failed to send response to slack. Status code was: {slack_client_response.status_code}.
-                The response from slack was: {slack_client_response.text}"""
-            )
-            return "Slack response to user failed"
-        else:
-            log.debug(f"Slack client response was: {slack_client_response.text}")
-        return slack_client_response
 
     def send_attachment(self, attachment):
         """

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -20,17 +20,25 @@ class Slack:
             "Authorization": f"Bearer {slack_token}",
         }
 
-    def post_message(self, message: str, channel: str) -> requests.models.Response:
+    def post_message(
+        self, message: str, channel: str, **kwargs
+    ) -> requests.models.Response:
         """
         Send slack message to channel. Channel can be a slack user ID to send direct message
         :param message: The text to send
         :param channel: The channel to send the message
         :return: requests.models.Response
         """
+
+        data = {"channel": channel, "text": message}
+
+        if kwargs.get("blocks"):
+            data["blocks"] = kwargs["blocks"]
+
         return self._handle_response(
             requests.post(
                 url=f"{self.slack_api_url}/chat.postMessage",
-                json={"channel": channel, "text": f"{message}"},
+                json=data,
                 headers=self.headers,
             )
         )
@@ -95,33 +103,6 @@ def slack_client_responder(
     return requests.post(
         url=url,
         json={"channel": user_id, "text": "From timereport", "attachments": attachment},
-        headers=headers,
-    )
-
-
-def slack_client_block_responder(
-    token, user_id, block, url="https://slack.com/api/chat.postMessage"
-):
-    """
-    Sends an direct message to a user.
-    https://slack.com/api/chat.postMessage
-
-    :param token: slack token
-    :param user_id: The user id
-    :param blocks: The slack attachment (A JSON-based array of structured blocks, presented as a URL-encoded string)
-    :param url: The slack URL
-    :return: request response object
-    """
-
-    log.debug(f"Will try to post direct message to user {user_id}")
-    log.debug(f"block generated looks like this {block}")
-    headers = {
-        "Content-Type": "application/json; charset=utf-8",
-        "Authorization": f"Bearer {token}",
-    }
-    return requests.post(
-        url=url,
-        json={"channel": user_id, "text": "From timereport", "blocks": block},
         headers=headers,
     )
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -47,23 +47,6 @@ def test_perform_empty_action():
     unstub()
 
 
-def test_perform_list_action():
-    fake_payload["text"] = ["list"]
-    fake_payload["user_name"] = "fake_username"
-    action = Action(fake_payload, fake_config)
-
-    when(action).send_block(message="fake list output").thenReturn("")
-    when(requests).get(
-        url=f"{fake_config['backend_url']}/event/users/fake_userid",
-        params={
-            "startDate": datetime.now().strftime("%Y-%m-01"),
-            "endDate": datetime.now().strftime("%Y-%m-31"),
-        },
-    ).thenReturn(mock({"status_code": 200, "text": "fake list output"}))
-    assert action.perform_action() == ""
-    unstub()
-
-
 def test_perform_lock():
     fake_payload["text"] = ["lock 2019-01"]
     action = Action(fake_payload, fake_config)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -10,6 +10,7 @@ from chalicelib.lib.slack import (
     slack_client_responder,
     slack_responder,
     Slack,
+    create_block_message,
 )
 
 fake_slack = Slack(slack_token="fake")
@@ -119,3 +120,10 @@ def test_delete_menu():
 
 def test_slack_handle_response_wrong_data_type():
     assert fake_slack._handle_response("wrong data type") is not None
+
+
+def test_create_block_message():
+    test = create_block_message(message=[{"event_date": "fake"}])
+    assert isinstance(test, list)
+    assert "text" in test[0].keys()
+    assert "type" in test[0].keys()


### PR DESCRIPTION
As part of #132 this fix remove the function `slack_client_block_responder` and implement the functionality into the `Slack` class.

Also remove the now unnecessary class method `send_block`