### PR TITLE
Add list option to lock

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -315,15 +315,22 @@ class Action:
         """
         Lock the timereport for month
 
+        create lock:
         /timereport lock 2019-08
+
+        list locks:
+        /timereport list 2020
         """
         if not self.arguments:
             return self.send_response(
                 f"Missing required argument. Here is an helpful message: {self._lock_action.__doc__}"
             )
 
-        event = create_lock(user_id=self.user_id, event_date=self.params[1])
+        if self.arguments[0] == "list":
+            return self.send_response(f"List not yet implemented :sad:")
+        event = create_lock(user_id=self.user_id, event_date=self.arguments[0])
         log.debug(f"lock event: {event}")
+
         response = lock_event(url=self.config["backend_url"], event=json.dumps(event))
         log.debug(f"response was: {response.text}")
         if response.status_code == 200:

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -328,19 +328,18 @@ class Action:
 
         if self.arguments[0] == "list":
             year = None
-            # Hämta locks för året
+
             try:
                 year = str(self.arguments[1])
             except IndexError:
-                now = datetime.datetime.now()
+                now = datetime.now()
                 year = now.year
 
-        locks = self._check_locks(
-            date=datetime.datime(year, 1, 1,),
-            second_date=datetime.datetime(year, 12, 1),
-        )
+            locks = self._check_locks(
+                date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
+            )
 
-        return self.send_response(f"Locks: {locks}")
+            return self.send_response(f"Locks: {locks}")
 
         event = create_lock(user_id=self.user_id, event_date=self.arguments[0])
         log.debug(f"lock event: {event}")
@@ -359,20 +358,22 @@ class Action:
         Check dates for lock.
         """
         dates_to_check = list()
+        locked_dates = list()
         for date in date_range(start_date=date, stop_date=second_date):
             if not date.strftime("%Y-%m") in dates_to_check:
                 dates_to_check.append(date.strftime("%Y-%m"))
 
         log.debug(f"Got {len(dates_to_check)} date(s) to check")
         for date in dates_to_check:
-            respone = read_lock(
+            response = read_lock(
                 url=self.config["backend_url"], user_id=self.user_id, date=date
             )
-            if respone.json():
+            if response.json():
                 log.info(f"Date {date} is locked")
-                dates_to_check.append(respone.json())
+                dates_to_check.append(response.json())
+                locked_dates.append(date)
 
-        return dates_to_check
+        return locked_dates
 
     def _valid_number_of_args(self, min_args: int, max_args: int) -> bool:
         """

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -422,6 +422,7 @@ class Action:
             url=self.config["backend_url"], user_id=self.user_id, date=year
         )
         locks = response.json()
+
         if not locks:
             return self.send_response(f"No locks found for year *{year}*")
 
@@ -429,7 +430,7 @@ class Action:
         self.slack.add_divider_block()
 
         for lock in locks:
-            self.slack.add_section_block(text=f"{lock} :lock:")
+            self.slack.add_section_block(text=f"{lock.get('event_date')} :lock:")
 
         self.slack.post_message(message="From timereport", channel=self.user_id)
         return ""

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -331,7 +331,7 @@ class Action:
             year = None
 
             try:
-                year = str(self.arguments[1])
+                year = int(self.arguments[1])
             except IndexError:
                 now = datetime.now()
                 year = now.year

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -422,11 +422,11 @@ class Action:
             date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
         )
 
-        self.slack.add_section_block(text=f"Locks found for months in {year}")
+        self.slack.add_section_block(text=f"Locks found for months in *{year}*")
         self.slack.add_divider_block()
 
         for lock in locks:
-            self.slack.add_section_block(text=f"Month: {lock} :lock:")
+            self.slack.add_section_block(text=f"{lock} :lock:")
 
         self.slack.post_message(message="From timereport", channel=self.user_id)
         return ""

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -327,7 +327,7 @@ class Action:
             )
 
         if self.arguments[0] == "list":
-            return self.send_response(f"List not yet implemented :sad:")
+            return self.send_response(f"List not yet implemented :cry:")
         event = create_lock(user_id=self.user_id, event_date=self.arguments[0])
         log.debug(f"lock event: {event}")
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -335,8 +335,9 @@ class Action:
                 now = datetime.now()
                 year = now.year
 
+            self.slack.ack_response(self.response_url)
             locks = self._check_locks(
-                date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
+                date=datetime(year, 1, 1), second_date=datetime(year, 12, 1)
             )
 
             return self.send_response(f"Locks: {locks}")

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -327,7 +327,18 @@ class Action:
             )
 
         if self.arguments[0] == "list":
-            return self.send_response(f"List not yet implemented :cry:")
+            year = None
+            # Hämta locks för året
+            try:
+                year = str(self.arguments[1])
+            except IndexError:
+                now = datetime.datetime.now()
+                year = now.year
+
+            return self.send_response(
+                f"List not yet implemented :cry:. But you specified year {year}"
+            )
+
         event = create_lock(user_id=self.user_id, event_date=self.arguments[0])
         log.debug(f"lock event: {event}")
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -335,9 +335,12 @@ class Action:
                 now = datetime.datetime.now()
                 year = now.year
 
-            return self.send_response(
-                f"List not yet implemented :cry:. But you specified year {year}"
-            )
+        locks = self._check_locks(
+            date=datetime.datime(year, 1, 1,),
+            second_date=datetime.datetime(year, 12, 1),
+        )
+
+        return self.send_response(f"Locks: {locks}")
 
         event = create_lock(user_id=self.user_id, event_date=self.arguments[0])
         log.debug(f"lock event: {event}")
@@ -351,11 +354,10 @@ class Action:
             self.send_response(message=f"Lock failed! :cry:")
             return ""
 
-    def _check_locks(self, date: datetime, second_date: datetime) -> bool:
+    def _check_locks(self, date: datetime, second_date: datetime) -> list:
         """
         Check dates for lock.
         """
-        is_locked = False
         dates_to_check = list()
         for date in date_range(start_date=date, stop_date=second_date):
             if not date.strftime("%Y-%m") in dates_to_check:
@@ -368,9 +370,9 @@ class Action:
             )
             if respone.json():
                 log.info(f"Date {date} is locked")
-                is_locked = True
+                dates_to_check.append(respone.json())
 
-        return is_locked
+        return dates_to_check
 
     def _valid_number_of_args(self, min_args: int, max_args: int) -> bool:
         """

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -321,9 +321,10 @@ class Action:
         list locks:
         /timereport list 2020
         """
-        if not self.arguments:
+
+        if not self._valid_number_of_args(min_args=1, max_args=2):
             return self.send_response(
-                f"Missing required argument. Here is an helpful message: {self._lock_action.__doc__}"
+                message=f"Got the wrong number of arguments for {self.action}. See these examples: {self._lock_action.__doc__}"
             )
 
         if self.arguments[0] == "list":

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -418,8 +418,8 @@ class Action:
             now = datetime.now()
             year = now.year
 
-        locks = self._check_locks(
-            date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
+        locks = read_lock(
+            url=self.config["backend_url"], user_id=self.user_id, date=year
         )
         if not locks:
             return self.send_response(f"No locks found for year *{year}*")

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -336,9 +336,8 @@ class Action:
                 now = datetime.now()
                 year = now.year
 
-            self.slack.ack_response(self.response_url)
             locks = self._check_locks(
-                date=datetime(year, 1, 1), second_date=datetime(year, 12, 1)
+                date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
             )
 
             return self.send_response(f"Locks: {locks}")

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -421,6 +421,8 @@ class Action:
         locks = self._check_locks(
             date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
         )
+        if not locks:
+            return self.send_response(f"No locks found for year *{year}*")
 
         self.slack.add_section_block(text=f"Locks found for months in *{year}*")
         self.slack.add_divider_block()

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -418,9 +418,10 @@ class Action:
             now = datetime.now()
             year = now.year
 
-        locks = read_lock(
+        response = read_lock(
             url=self.config["backend_url"], user_id=self.user_id, date=year
         )
+        locks = response.json()
         if not locks:
             return self.send_response(f"No locks found for year *{year}*")
 

--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -336,6 +336,8 @@ class Action:
                 now = datetime.now()
                 year = now.year
 
+            self.slack.ack_response(response_url=self.response_url)
+
             locks = self._check_locks(
                 date=datetime(year, 1, 1), second_date=datetime(year, 12, 1),
             )

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -58,13 +58,11 @@ class Slack:
                     f"Slack responded with not ok. Message was: {validated_response}"
                 )
         except (AttributeError, ValueError) as error:
-            log.critical(
-                f"Unable get valid json from response. Error was: {error}",
-                exc_info=True,
-            )
-            log.debug(
-                f"HTTP code was: {response.status_code}. Text was: {response.text}"
-            )
+            if not response.text == "ok" and response.status_code == 200:
+                log.critical(
+                    f"Unable get valid json from response. Error was: {error}",
+                    exc_info=True,
+                )
 
         return response
 

--- a/chalicelib/lib/slack.py
+++ b/chalicelib/lib/slack.py
@@ -1,11 +1,12 @@
-import os
-import requests
-from urllib.parse import parse_qs
-import logging
-import json
-import hmac
-import hashlib
 import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+from urllib.parse import parse_qs
+
+import requests
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +61,9 @@ class Slack:
             log.critical(
                 f"Unable get valid json from response. Error was: {error}",
                 exc_info=True,
+            )
+            log.debug(
+                f"HTTP code was: {response.status_code}. Text was: {response.text}"
             )
 
         return response
@@ -247,4 +251,3 @@ def delete_message_menu(user_name, date):
         }
     ]
     return attachment
-

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -117,10 +117,6 @@ def test_delete_menu():
     assert test_result_dict.get("fields")
 
 
-def test_slack_handle_response_wrong_data_type():
-    assert fake_slack._handle_response("wrong data type") is not None
-
-
 def test_add_divider():
     fake_slack = Slack(slack_token="fake")
     fake_slack.add_divider_block()


### PR DESCRIPTION
A PoC of listing locks with `/timereport-dev lock list`.
Right now it will check locks for a given year. This means 12 requests against our timereport API.
This result in the problem with `operation_timeout` (see #99 ).

one fix for this could be adding the possibility to do one request that fetches all events for the given year.

Any feedback on the current implementation would be helpful. 
