### PR TITLE
Add support for non full hours

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -268,6 +268,11 @@ class AddAction(BaseAction):
         <day> can be
         "today" - Add event for todays date
         a date of the format "2020-03-10" or a range such as "2020-03-10:2020-03-17"
+
+        <hours> can be:
+        Nothing - Will default to a full workday
+        Full hours (1, 2, 3 etc.)
+        Partial hours (5.5 etc.) - `.5` = 30 minutes, `.25` = 15 minutes etc.
         """
 
     def perform_action(self):
@@ -287,7 +292,7 @@ class AddAction(BaseAction):
 
         # validate hours
         try:
-            hours: int = round(float(hours))
+            hours: float = float(hours)
         except ValueError:
             return self.send_response(message=f"Could not parse hours: {hours}")
 
@@ -450,7 +455,7 @@ class EditAction(BaseAction):
         date_input = self.arguments[1]
 
         try:
-            hours = round(float(self.arguments[2]))
+            hours = float(self.arguments[2])
         except ValueError as error:
             log.error(f"Failed to parse hours. Error was: {error}")
             return self.send_response(message="Could not parse hours")
@@ -588,7 +593,7 @@ class ListAction(BaseAction):
         total_per_type = defaultdict(int)
         total_absent = 0
         for event in self._filter_non_workdays(list_data, period_data):
-            hours = int(event.get("hours"))
+            hours = float(event.get("hours"))
             total_absent += hours
             total_per_type[event.get("reason")] += hours
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,12 +55,14 @@ def test_empty_list(chalice_app):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("date", ["today", "2020-01-01"])
-def test_add_command_accepted(chalice_app, date):
+@pytest.mark.parametrize(
+    "date,hours", [("today", "8"), ("2020-01-01", "8"), ("today", "6.5")]
+)
+def test_add_command_accepted(chalice_app, date, hours):
     user_id = f"{random.randint(0, 10000)}"
     r = call_from_slack(
         chalice_app=chalice_app,
-        full_command=f"add vab {date} 8",
+        full_command=f"add vab {date} {hours}",
         user_id=user_id,
         user_name="mattias",
     )
@@ -91,6 +93,7 @@ def test_add_command_accepted(chalice_app, date):
     assert rl["response"]["statusCode"] == 200
     assert "nothing to list" not in rl["slack_message"][1]["json"]["text"]
     assert "Reason: *vab*" in get_raw_block_text(slack_message=rl["slack_message"])
+    assert f"Hours: *{hours}" in get_raw_block_text(slack_message=rl["slack_message"])
 
     # Delete report
     r = call_from_slack(
@@ -177,8 +180,8 @@ def test_list_with_total_hours(chalice_app):
     assert "Reason: *vab*" in raw_block_text
 
     # 152 hours total in month, 8 vab on weekdays and 16 vab on weekends/holidays (not counted)
-    assert "144 / 152 (-8)" in raw_block_text
-    assert "vab: 8h" in raw_block_text
+    assert "144.0 / 152 (-8.0)" in raw_block_text
+    assert "vab: 8.0h" in raw_block_text
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Not "safe" for rounding errors, but I think this is good enough for
time. We will likely never encounter problematic rounding if the users
report resonable values.

Fix #189