### PR TITLE
Don't use v1 api when loading locks

### DIFF
--- a/chalicelib/action.py
+++ b/chalicelib/action.py
@@ -236,10 +236,9 @@ class LockAction(Action):
             now = datetime.now()
             year = now.year
 
-        response = read_lock(
-            url=self.config["backend_url"], user_id=self.user_id, date=year
-        )
+        response = read_lock(url=self.config["backend_url"], user_id=self.user_id)
         locks = response.json()
+        locks = [l for l in locks if l["event_date"].startswith(str(year))]
 
         if not locks:
             return self.send_response(f"No locks found for year *{year}*")

--- a/chalicelib/lib/api.py
+++ b/chalicelib/lib/api.py
@@ -67,16 +67,15 @@ def create_lock(url: str, user_id: str, date: str) -> requests.models.Response:
     return response
 
 
-def read_lock(url: str, user_id: str, date: str) -> requests.models.Response:
+def read_lock(url: str, user_id: str) -> requests.models.Response:
     """
     List locks for user. Response contains a list of all locks for user
     and will need to get parsed on our side.
     :param url: str
     :param user_id: str
-    :param date: str
     :return: requests.models.Response
     """
-    url = f"{url}/lock/users/{user_id}/{date}"
+    url = f"{url}/users/{user_id}/locks"
     headers = {"Content-Type": "application/json"}
-    response = requests.get(url=url, headers=headers)
+    response = requests.get(url=url, headers=headers, timeout=3)
     return response

--- a/chalicelib/lib/helpers.py
+++ b/chalicelib/lib/helpers.py
@@ -128,15 +128,20 @@ def check_locks(
     Get a list of locks for the specified user and daterange
     """
     dates_to_check = list()
-    locked_dates = list()
     for date in date_range(start_date=date, stop_date=second_date):
         if not date.strftime("%Y-%m") in dates_to_check:
             dates_to_check.append(date.strftime("%Y-%m"))
 
     log.debug(f"Got {len(dates_to_check)} date(s) to check")
+    response = read_lock(url=config["backend_url"], user_id=user_id)
+    data = response.json()
+    if not data:
+        return []
+
+    locked_dates = list()
+    locked_months = [d["event_date"] for d in data]
     for date in dates_to_check:
-        response = read_lock(url=config["backend_url"], user_id=user_id, date=date)
-        if response.json():
+        if date in locked_months:
             log.info(f"Date {date} is locked")
             dates_to_check.append(response.json())
             locked_dates.append(date)


### PR DESCRIPTION
Removed in https://github.com/codelabsab/timereport-api/pull/33